### PR TITLE
Fix typo: s/dataa/data/

### DIFF
--- a/locale/ar/LC_MESSAGES/extdev/index.po
+++ b/locale/ar/LC_MESSAGES/extdev/index.po
@@ -328,7 +328,7 @@ msgstr ""
 #: ../../sphinx/doc/extdev/index.rst:180
 msgid ""
 "It has event handlers for :event:`env-merge-info` and :event:`env-purge-doc`"
-" events if it stores dataa to the build environment object (env) during the "
+" events if it stores data to the build environment object (env) during the "
 "reading phase."
 msgstr ""
 

--- a/locale/ca_ES/LC_MESSAGES/extdev/index.po
+++ b/locale/ca_ES/LC_MESSAGES/extdev/index.po
@@ -328,7 +328,7 @@ msgstr ""
 #: ../../sphinx/doc/extdev/index.rst:180
 msgid ""
 "It has event handlers for :event:`env-merge-info` and :event:`env-purge-doc`"
-" events if it stores dataa to the build environment object (env) during the "
+" events if it stores data to the build environment object (env) during the "
 "reading phase."
 msgstr ""
 

--- a/locale/de/LC_MESSAGES/extdev/index.po
+++ b/locale/de/LC_MESSAGES/extdev/index.po
@@ -328,7 +328,7 @@ msgstr ""
 #: ../../sphinx/doc/extdev/index.rst:180
 msgid ""
 "It has event handlers for :event:`env-merge-info` and :event:`env-purge-doc`"
-" events if it stores dataa to the build environment object (env) during the "
+" events if it stores data to the build environment object (env) during the "
 "reading phase."
 msgstr ""
 

--- a/locale/es/LC_MESSAGES/extdev/index.po
+++ b/locale/es/LC_MESSAGES/extdev/index.po
@@ -328,7 +328,7 @@ msgstr ""
 #: ../../sphinx/doc/extdev/index.rst:180
 msgid ""
 "It has event handlers for :event:`env-merge-info` and :event:`env-purge-doc`"
-" events if it stores dataa to the build environment object (env) during the "
+" events if it stores data to the build environment object (env) during the "
 "reading phase."
 msgstr ""
 

--- a/locale/fr/LC_MESSAGES/extdev/index.po
+++ b/locale/fr/LC_MESSAGES/extdev/index.po
@@ -332,7 +332,7 @@ msgstr ""
 #: ../../sphinx/doc/extdev/index.rst:180
 msgid ""
 "It has event handlers for :event:`env-merge-info` and :event:`env-purge-doc`"
-" events if it stores dataa to the build environment object (env) during the "
+" events if it stores data to the build environment object (env) during the "
 "reading phase."
 msgstr ""
 

--- a/locale/it_IT/LC_MESSAGES/extdev/index.po
+++ b/locale/it_IT/LC_MESSAGES/extdev/index.po
@@ -328,7 +328,7 @@ msgstr ""
 #: ../../sphinx/doc/extdev/index.rst:180
 msgid ""
 "It has event handlers for :event:`env-merge-info` and :event:`env-purge-doc`"
-" events if it stores dataa to the build environment object (env) during the "
+" events if it stores data to the build environment object (env) during the "
 "reading phase."
 msgstr ""
 

--- a/locale/ja/LC_MESSAGES/extdev/index.po
+++ b/locale/ja/LC_MESSAGES/extdev/index.po
@@ -366,7 +366,7 @@ msgstr ""
 #: ../../sphinx/doc/extdev/index.rst:180
 msgid ""
 "It has event handlers for :event:`env-merge-info` and :event:`env-purge-doc`"
-" events if it stores dataa to the build environment object (env) during the "
+" events if it stores data to the build environment object (env) during the "
 "reading phase."
 msgstr ""
 

--- a/locale/ko/LC_MESSAGES/extdev/index.po
+++ b/locale/ko/LC_MESSAGES/extdev/index.po
@@ -328,7 +328,7 @@ msgstr ""
 #: ../../sphinx/doc/extdev/index.rst:180
 msgid ""
 "It has event handlers for :event:`env-merge-info` and :event:`env-purge-doc`"
-" events if it stores dataa to the build environment object (env) during the "
+" events if it stores data to the build environment object (env) during the "
 "reading phase."
 msgstr ""
 

--- a/locale/pl_PL/LC_MESSAGES/extdev/index.po
+++ b/locale/pl_PL/LC_MESSAGES/extdev/index.po
@@ -328,7 +328,7 @@ msgstr ""
 #: ../../sphinx/doc/extdev/index.rst:180
 msgid ""
 "It has event handlers for :event:`env-merge-info` and :event:`env-purge-doc`"
-" events if it stores dataa to the build environment object (env) during the "
+" events if it stores data to the build environment object (env) during the "
 "reading phase."
 msgstr ""
 

--- a/locale/pot/extdev/index.pot
+++ b/locale/pot/extdev/index.pot
@@ -217,7 +217,7 @@ msgid "The core logic of the extension is parallelly executable during the readi
 msgstr ""
 
 #: ../../sphinx/doc/extdev/index.rst:180
-msgid "It has event handlers for :event:`env-merge-info` and :event:`env-purge-doc` events if it stores dataa to the build environment object (env) during the reading phase."
+msgid "It has event handlers for :event:`env-merge-info` and :event:`env-purge-doc` events if it stores data to the build environment object (env) during the reading phase."
 msgstr ""
 
 #: ../../sphinx/doc/extdev/index.rst:184

--- a/locale/pt_BR/LC_MESSAGES/extdev/index.po
+++ b/locale/pt_BR/LC_MESSAGES/extdev/index.po
@@ -432,7 +432,7 @@ msgstr ""
 #: ../../sphinx/doc/extdev/index.rst:180
 msgid ""
 "It has event handlers for :event:`env-merge-info` and :event:`env-purge-doc`"
-" events if it stores dataa to the build environment object (env) during the "
+" events if it stores data to the build environment object (env) during the "
 "reading phase."
 msgstr ""
 

--- a/locale/ru/LC_MESSAGES/extdev/index.po
+++ b/locale/ru/LC_MESSAGES/extdev/index.po
@@ -328,7 +328,7 @@ msgstr ""
 #: ../../sphinx/doc/extdev/index.rst:180
 msgid ""
 "It has event handlers for :event:`env-merge-info` and :event:`env-purge-doc`"
-" events if it stores dataa to the build environment object (env) during the "
+" events if it stores data to the build environment object (env) during the "
 "reading phase."
 msgstr ""
 

--- a/locale/sr/LC_MESSAGES/extdev/index.po
+++ b/locale/sr/LC_MESSAGES/extdev/index.po
@@ -328,7 +328,7 @@ msgstr ""
 #: ../../sphinx/doc/extdev/index.rst:180
 msgid ""
 "It has event handlers for :event:`env-merge-info` and :event:`env-purge-doc`"
-" events if it stores dataa to the build environment object (env) during the "
+" events if it stores data to the build environment object (env) during the "
 "reading phase."
 msgstr ""
 

--- a/locale/sr_RS/LC_MESSAGES/extdev/index.po
+++ b/locale/sr_RS/LC_MESSAGES/extdev/index.po
@@ -328,7 +328,7 @@ msgstr ""
 #: ../../sphinx/doc/extdev/index.rst:180
 msgid ""
 "It has event handlers for :event:`env-merge-info` and :event:`env-purge-doc`"
-" events if it stores dataa to the build environment object (env) during the "
+" events if it stores data to the build environment object (env) during the "
 "reading phase."
 msgstr ""
 

--- a/locale/zh_CN/LC_MESSAGES/extdev/index.po
+++ b/locale/zh_CN/LC_MESSAGES/extdev/index.po
@@ -347,7 +347,7 @@ msgstr ""
 #: ../../sphinx/doc/extdev/index.rst:180
 msgid ""
 "It has event handlers for :event:`env-merge-info` and :event:`env-purge-doc`"
-" events if it stores dataa to the build environment object (env) during the "
+" events if it stores data to the build environment object (env) during the "
 "reading phase."
 msgstr ""
 


### PR DESCRIPTION
Assuming "dataa" is a typo for "data".