### PR TITLE
fix typo in japanese: あありません => ありません

### DIFF
--- a/locale/ja/LC_MESSAGES/ext/napoleon.po
+++ b/locale/ja/LC_MESSAGES/ext/napoleon.po
@@ -314,7 +314,7 @@ msgid ""
 "and won't show up in the docs."
 msgstr ""
 "`Python 2/3 compatible annotations`_ "
-"は現在のところSphinxでサポートされていません。また、ドキュメント上に登場することもあありません。"
+"は現在のところSphinxでサポートされていません。また、ドキュメント上に登場することもありません。"
 
 #: ../../sphinx/doc/ext/napoleon.rst:252
 msgid "Configuration"

--- a/locale/ja/LC_MESSAGES/usage/extensions/napoleon.po
+++ b/locale/ja/LC_MESSAGES/usage/extensions/napoleon.po
@@ -310,7 +310,7 @@ msgid ""
 "and won't show up in the docs."
 msgstr ""
 "`Python 2/3 compatible annotations`_ "
-"は現在のところSphinxでサポートされていません。また、ドキュメント上に登場することもあありません。"
+"は現在のところSphinxでサポートされていません。また、ドキュメント上に登場することもありません。"
 
 #: ../../sphinx/doc/usage/extensions/napoleon.rst:271
 msgid "Configuration"


### PR DESCRIPTION
I am pretty sure these "あありません" are typos, and corrected them to "ありません".