### PR TITLE
Add monthly grouped auto-updates for GitHub Actions by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+       # Name for the group, which will be used in PR titles and branch names
+       all-github-actions:
+          # Group all updates together
+          patterns:
+            - "*"


### PR DESCRIPTION
Just in case you wanted monthly grouped auto-updates for GitHub Actions on this repo as well. It would fix one of the deprecation warnings in the [actions](https://github.com/sphinx-doc/sphinx-doc-translations/actions/runs/6425995204):
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/cache@v2, actions/setup-python@v2, ad-m/github-push-action@v0.6.0. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```