### PR TITLE
Fix set-output deprecation warning in Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
     - name: Get date
       id: get-date
       run: |
-        echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
-        echo "::set-output name=yyyymm::$(/bin/date -u "+%Y%m")"
+        echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+        echo "yyyymm=$(/bin/date -u "+%Y%m")" >> $GITHUB_OUTPUT
       shell: bash
     - name: cache pip
       id: cache-pip


### PR DESCRIPTION
`main.yml` workflow [actions](https://github.com/sphinx-doc/sphinx-doc-translations/actions/runs/6425995204) are showing the following warning:
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

To attempt a fix, I followed the advice in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/, although not sure how to test that was correct.

Fixes #23