### PR TITLE
Install all docs requirements, including optionals

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/sphinx-doc/sphinx.git
+sphinx[docs] @ git+https://github.com/sphinx-doc/sphinx.git
 sphinx-intl>=2.1.0


### PR DESCRIPTION
sphinxcontrib-websupport is set as an optional dependency for target [docs] in sphinx's pyproject.toml. This will make sure to install it as well.

This solves the current error when building translated Sphinx's documentation:

```
[2Kreading sources... [100%] usage/theming
WARNING: autodoc: failed to import method 'websupport.WebSupport.build' from module 'sphinxcontrib'; the following exception was raised:
No module named 'sphinxcontrib.websupport'
```

The above error can be seen in readthedocs build logs like https://readthedocs.org/projects/sphinx-pt-br/builds/22377307/ in build step or raw log.