### PR TITLE
Enable pull_request event in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
       run: sudo apt-get install graphviz
     - name: Install dependencies
       run: |
+        git fetch origin master --depth 1
         git branch -a
         git checkout master  # attach this repo
         git submodule init

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: update-translations
 
 on:
+  pull_request:
   schedule:
     - cron: "0 0 * * *" #runs at 00:00 UTC everyday
 
@@ -62,6 +63,7 @@ jobs:
         git add sphinx
         git commit -m "[skip ci] by GHA https://github.com/${{ github.repository }}/actions/runs/${{ github.run_number }}"
     - name: GitHub Push
+      if: github.event_name != 'pull_request'
       uses: ad-m/github-push-action@v0.6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Run the steps from 'main.yml' in pull requests, but without pushing the changes. This allows us to find errors in script changes and to effectively testing dependabot changes before bringing it to prod.