### PR TITLE
Create test-translations.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
         git config --global user.name "sphinx-auto-update"
         git add locale
         git add sphinx
-        git commit -m "[skip ci] by GHA https://github.com/${{ github.repository }}/actions/runs/${{ github.run_number }}"
+        git commit -m "Update translations by GHA https://github.com/${{ github.repository }}/actions/runs/${{ github.run_number }}"
     - name: GitHub Push
       if: github.event_name != 'pull_request'
       uses: ad-m/github-push-action@v0.8.0

--- a/.github/workflows/test-translations.yml
+++ b/.github/workflows/test-translations.yml
@@ -1,0 +1,81 @@
+name: Test translations
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+    - '**.po'
+    branches:
+    - master
+  push:
+    paths:
+    - '**.po'
+    branches:
+    - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      languages: ${{ steps.languages.outputs.languages }}
+
+    steps:
+    - name: Grab the repo src
+      uses: actions/checkout@v4
+
+    - name: List languages
+      id: languages
+      working-directory: locale
+      run: |
+        list=$(find * -maxdepth 0 -type d | sed '/pot/d' | jq -nRc '[inputs]')
+        echo "languages=$list" >> $GITHUB_OUTPUT
+
+
+  test-translation:
+    runs-on: ubuntu-latest
+    needs: matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ${{fromJson(needs.matrix.outputs.languages)}}
+
+    steps:
+    - name: Grab the repo src
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3'
+        cache: 'pip'
+
+    - name: Update submodule
+      run: |
+        git submodule init
+        git submodule update
+        
+    - name: Install dependencies
+      run: |
+        pip install -U -r requirements.txt
+      
+    - name: Set Sphinx problem matcher
+      uses: sphinx-doc/github-problem-matcher@v1.0
+
+    - name: Build translated docs in ${{ matrix.language }}
+      run: |
+        sphinx-build ./sphinx/doc/ ./_build/html -b html -D locale_dirs=$(realpath locale) -D language=${{ matrix.language }} -D gettext_compact=0
+
+    - name: Set Sphinx Lint problem matcher
+      if: always()
+      uses: rffontenelle/sphinx-lint-problem-matcher@v1.0.0
+
+    - name: Lint translation file
+      if: always()
+      run: sphinx-lint locale/${{ matrix.language }}


### PR DESCRIPTION
This workflow is intended for a centralized and easy to find point of syntax errors in translation files. It was based on [my own contribution](https://github.com/pypa/packaging.python.org/pull/1431) to [Python Packaging User Guide](https://packaging.python.org)

Currently, one can only find syntax errors by browsing the logs in Read The Docs, and each language is its own separated rtd project. I doubt anyone will do that, except for me.

Translation file update triggers in both push and pull request events. E.g. When Transifex files a pull request with new translations.