### PR TITLE
Revamp .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,16 +4,14 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3"
-  commands:
-    # install requirements
-    - pip install -r requirements.txt
-    # initialise submodule (https://github.com/sphinx-doc/sphinx.git)
-    - git submodule init
-    - git submodule update
-    # run Sphinx
-    - >
-      sphinx-build ./sphinx/doc/ ./_readthedocs/html 
-      -b html  
-      -D locale_dirs=$(realpath locale)
-      -D language=$(python convert_language_tag.py)
-      -D gettext_compact=0
+  apt_packages:
+    - graphviz
+  jobs:
+    post_create_environment:
+      - git clone https://github.com/sphinx-docs/sphinx ../sphinx
+      - cp -A locale ../sphinx/doc/
+
+sphinx:
+  builder: html
+  configuration: ../sphinx/doc/conf.py
+  fail_on_warning: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,10 +8,11 @@ build:
     - graphviz
   jobs:
     post_create_environment:
-      - git clone https://github.com/sphinx-doc/sphinx ../sphinx
-      - cp -a locale ../sphinx/doc/
+      - git clone https://github.com/sphinx-doc/sphinx sphinx
+      - cp -a locale sphinx/doc/
 
-sphinx:
-  builder: html
-  configuration: ../sphinx/doc/conf.py
-  fail_on_warning: true
+python:
+  install:
+    - requirements: requirements.txt
+    - method: pip
+      path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,5 +14,3 @@ build:
 python:
   install:
     - requirements: requirements.txt
-    - method: pip
-      path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,9 @@ build:
       - git clone https://github.com/sphinx-doc/sphinx sphinx
       - cp -a locale sphinx/doc/
 
+formats:
+  - pdf
+
 python:
   install:
     - requirements: requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,9 +8,11 @@ build:
     - graphviz
   jobs:
     post_create_environment:
-      - git clone https://github.com/sphinx-doc/sphinx sphinx
       - cp -a locale sphinx/doc/
 
+submodules:
+  include: all
+  
 formats:
   - pdf
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ build:
     - graphviz
   jobs:
     post_create_environment:
-      - git clone https://github.com/sphinx-docs/sphinx ../sphinx
+      - git clone https://github.com/sphinx-doc/sphinx ../sphinx
       - cp -A locale ../sphinx/doc/
 
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ build:
   jobs:
     post_create_environment:
       - git clone https://github.com/sphinx-doc/sphinx ../sphinx
-      - cp -A locale ../sphinx/doc/
+      - cp -a locale ../sphinx/doc/
 
 sphinx:
   builder: html


### PR DESCRIPTION
Replace `build.commands` statements in .readthedocs.yml with:
- `build.apt_packages` to install graphviz (fixes #34)
- `build.jobs.post_create_environment` for placing translation files into the sourcedir
- `submodules` to set sphinx source files' repository
- `formats` to make PDF build available for download
- `python` for installing dependencies (which includes requirements.txt from sphinx's repository

`sphinx/doc/conf.py` is automatically found by RTD after having the sphinx submodule initialized.