### PR TITLE
fix misspelling of sphinx.ext.imgconverter

### DIFF
--- a/locale/fr/LC_MESSAGES/usage/extensions/imgconverter.po
+++ b/locale/fr/LC_MESSAGES/usage/extensions/imgconverter.po
@@ -26,7 +26,7 @@ msgid ""
 ":mod:`sphinx.ext.imgconverter` -- A reference image converter using "
 "Imagemagick"
 msgstr ""
-":mod:`sphinx.ext.ext.imgconverter` -- Un convertisseur d'image de référence "
+":mod:`sphinx.ext.imgconverter` -- Un convertisseur d'image de référence "
 "utilisant Imagemagick"
 
 #: ../../sphinx/doc/usage/extensions/imgconverter.rst:11


### PR DESCRIPTION
This can cause french users to use a wrong ID for the extension if they don't pay attention