### PR TITLE
Install deps from Sphinx's pyproject.toml in .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,7 @@ formats:
 
 python:
   install:
-    - requirements: requirements.txt
+    - method: pip
+      path: sphinx
+      extra_requirements:
+        - docs


### PR DESCRIPTION
Avoid installing unnecessary dependencies for building docs, e.g. sphinx-lint