### PR TITLE
Disable PDF building in .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,9 +12,6 @@ build:
 
 submodules:
   include: all
-  
-formats:
-  - pdf
 
 python:
   install:


### PR DESCRIPTION
Some languages are failing to build PDF and HTML pages are more important. See  #56
