### PR TITLE
Upload Sphinx logs as artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,3 +87,9 @@ jobs:
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/${{ github.repository }}/actions/workflows/test-translations.yml/dispatches \
           -d '{"ref":"master"}'
+    #5. Upload sphinx log as artifact 
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: sphinx-logs
+        path: /tmp/sphinx*.log


### PR DESCRIPTION
Store the log file generated by Sphinx when a sphinx-build fails in order to try to help debug issues.