### PR TITLE
Add sphinx.configuration to .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,6 @@
 version: 2
+sphinx:
+  configuration: doc/conf.py
 
 build:
   os: ubuntu-22.04

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 sphinx:
-  configuration: doc/conf.py
+  configuration: sphinx/doc/conf.py
 
 build:
   os: ubuntu-22.04


### PR DESCRIPTION
Building on Read the Docs without `sphinx.configuration` is deprecated and started failing the build. https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/