### PR TITLE
Set CI to run on every 6 hours

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
   schedule:
-    - cron: "0 0 * * *" #runs at 00:00 UTC everyday
+    - cron: "0 */6 * * *" # runs at 0 minutes past the hour, every 6 hours
 
 jobs:
   update:


### PR DESCRIPTION
The CI is already set to commit only relevant changes, so the git history shouldn't be too polluted. This would cause new translation contributions to arrive faster in this repository ­— which would be published earlier — and new doc strings would reach Transifex faster.