### PR TITLE
Refactor .readthedocs.yml to support PEP 735

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,7 @@ build:
       - cp -a locales sphinx/doc/
     install:
       - pip install --upgrade pip
-      - pip install sphinx/ --group 'docs'
+      - pip install --group sphinx/pyproject.toml:docs
 
 submodules:
   include: all


### PR DESCRIPTION
Installing dependency group requires changing how the Read The Docs config file installs dependencies.

Fixes #69