### PR TITLE
devcontainers-contrib has been moved to devcontainers-extra, verup container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,13 +2,13 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
 	"name": "Python 3",
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/python:3.13-bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/git:1": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {},
-		"ghcr.io/devcontainers-contrib/features/act:1": {},
-		"ghcr.io/devcontainers-contrib/features/ruff:1": {}
+		"ghcr.io/devcontainers-extra/features/act:1": {},
+		"ghcr.io/devcontainers-extra/features/ruff:2": {}
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
- devcontainers-contrib has been moved to devcontainers-extra
- update python container image due to pgp-sign issue
  - https://github.com/yarnpkg/yarn/issues/9216